### PR TITLE
Integrate RL model with match selector utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # stadiony_ai
+
+This repository now includes a simple utility for ranking match predictions by
+probability and building the longest series of high-confidence picks, ignoring
+dates and kick-off times.
+
+## Match selector
+
+`match_selector.py` demonstrates how to:
+
+1. Store match predictions with probabilities.
+2. Order matches from most to least probable.
+3. Create a sequence of picks above a probability threshold.
+
+Run the example:
+
+```bash
+python match_selector.py
+```
+
+The script prints the matches in order of confidence.
+
+### RL integration
+
+If you train a reinforcement-learning model (for example with
+`stadiiony_szkolenie.py`), you can plug its policy into the selector. The
+helper functions convert the model's action probabilities into
+`MatchPrediction` objects and build the highest-confidence series:
+
+```python
+from datetime import datetime
+from stable_baselines3 import PPO
+
+from match_selector import rl_confident_series
+
+model = PPO.load("path/to/model.zip")
+observations = [...]  # list of environment observations for each match
+meta = [("Team A vs Team B", datetime(2025, 6, 1, 18, 0)), ...]
+
+series = rl_confident_series(model, observations, meta, min_probability=0.6)
+```
+
+`series` now contains matches sorted purely by the model's confidence,
+ignoring dates or kick-off times.

--- a/match_selector.py
+++ b/match_selector.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, List, Sequence, Tuple
+
+try:  # Optional dependency
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - executed when numpy missing
+    np = None  # type: ignore
+
+try:  # stable-baselines3 is optional when using RL helpers
+    from stable_baselines3.common.base_class import BaseAlgorithm
+except Exception:  # pragma: no cover - only executed if library missing
+    BaseAlgorithm = Any
+
+
+@dataclass(frozen=True)
+class MatchPrediction:
+    """Single match prediction with probability of success.
+
+    Attributes:
+        name: Human readable name of the match.
+        start_time: Kick-off time. It is kept for reference but not used in
+            ordering.
+        probability: Estimated probability of the selected outcome (0-1).
+    """
+
+    name: str
+    start_time: datetime
+    probability: float
+
+
+def rank_by_probability(matches: Iterable[MatchPrediction]) -> List[MatchPrediction]:
+    """Return matches sorted descending by probability.
+
+    Args:
+        matches: Iterable of :class:`MatchPrediction`.
+
+    Returns:
+        A list of matches ordered from most to least probable. Date and time do
+        not influence the ranking.
+    """
+
+    return sorted(matches, key=lambda m: m.probability, reverse=True)
+
+
+def longest_confident_series(
+    matches: Iterable[MatchPrediction], *, min_probability: float = 0.5
+) -> List[MatchPrediction]:
+    """Select a sequence of high-confidence matches.
+
+    The function ranks all matches by probability and then keeps only those
+    whose probability is above ``min_probability``. The order is purely based on
+    probability, independent of match dates.
+
+    Args:
+        matches: Iterable of :class:`MatchPrediction`.
+        min_probability: Minimum probability required to keep a match in the
+            returned series.
+
+    Returns:
+        List of matches forming a series with the highest confidence first.
+    """
+
+    ranked = rank_by_probability(matches)
+    return [m for m in ranked if m.probability >= min_probability]
+
+
+def predictions_from_rl(
+    model: BaseAlgorithm,
+    observations: Sequence[np.ndarray],
+    meta: Sequence[Tuple[str, datetime]],
+    *,
+    action_index: int = 0,
+) -> List[MatchPrediction]:
+    """Convert RL policy outputs into :class:`MatchPrediction` objects.
+
+    Args:
+        model: Trained RL model compatible with ``stable_baselines3``.
+        observations: Sequence of environment observations for each match.
+        meta: Sequence of ``(name, start_time)`` pairs describing matches.
+        action_index: Index of the action interpreted as a "bet".
+
+    Returns:
+        List of :class:`MatchPrediction` with probabilities derived from the
+        model's action distribution.
+    """
+
+    preds: List[MatchPrediction] = []
+    for obs, (name, start_time) in zip(observations, meta):
+        if np is None:
+            raise ImportError("numpy is required for predictions_from_rl")
+        obs_arr = np.asarray(obs)[None, ...]
+        dist = model.policy.get_distribution(obs_arr)
+        probs = getattr(dist.distribution, "probs", None)
+        if probs is None:
+            logits = dist.distribution.logits
+            probs = logits.softmax(-1)
+        prob = float(probs[0][action_index])
+        preds.append(MatchPrediction(name, start_time, prob))
+    return preds
+
+
+def rl_confident_series(
+    model: BaseAlgorithm,
+    observations: Sequence[np.ndarray],
+    meta: Sequence[Tuple[str, datetime]],
+    *,
+    min_probability: float = 0.5,
+    action_index: int = 0,
+) -> List[MatchPrediction]:
+    """Build a confident series using an RL model for probabilities."""
+
+    matches = predictions_from_rl(model, observations, meta, action_index=action_index)
+    return longest_confident_series(matches, min_probability=min_probability)
+
+
+if __name__ == "__main__":
+    sample_matches = [
+        MatchPrediction("Team A vs Team B", datetime(2025, 6, 1, 18, 0), 0.72),
+        MatchPrediction("Team C vs Team D", datetime(2025, 6, 2, 21, 0), 0.65),
+        MatchPrediction("Team E vs Team F", datetime(2025, 5, 30, 16, 0), 0.81),
+    ]
+
+    series = longest_confident_series(sample_matches, min_probability=0.6)
+    for match in series:
+        print(f"{match.name}: {match.probability:.0%}")


### PR DESCRIPTION
## Summary
- add helpers to turn RL policy outputs into probability-ranked matches
- document how to plug a trained RL model into the selector
- expose `select_longest_series` in `stadiiony_szkolenie.py` to build high-confidence series from RL predictions

## Testing
- `python match_selector.py`
- `python -m py_compile match_selector.py stadiiony_szkolenie.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4eaf8b4c0832d9e6331b6dacbed28