### PR TITLE
Improve match display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository now includes a simple utility for ranking match predictions by
 probability and building the longest series of high-confidence picks, ignoring
-dates and kick-off times.
+dates and kick-off times. You can also generate an arbitrarily long series of
+predictions simply by taking the top-N most confident matches.
 
 ## Match selector
 
@@ -11,6 +12,7 @@ dates and kick-off times.
 1. Store match predictions with probabilities.
 2. Order matches from most to least probable.
 3. Create a sequence of picks above a probability threshold.
+4. Grab the top-N most confident matches for the longest possible streak.
 
 Run the example:
 
@@ -18,7 +20,8 @@ Run the example:
 python match_selector.py
 ```
 
-The script prints the matches in order of confidence.
+The script prints each match with its kick-off time and probability,
+ordered by confidence.
 
 ### RL integration
 
@@ -31,14 +34,18 @@ helper functions convert the model's action probabilities into
 from datetime import datetime
 from stable_baselines3 import PPO
 
-from match_selector import rl_confident_series
+from match_selector import rl_confident_series, rl_max_series
 
 model = PPO.load("path/to/model.zip")
 observations = [...]  # list of environment observations for each match
 meta = [("Team A vs Team B", datetime(2025, 6, 1, 18, 0)), ...]
 
+# Top matches above a fixed probability threshold
 series = rl_confident_series(model, observations, meta, min_probability=0.6)
+
+# Alternatively, simply take the five most confident predictions
+top5 = rl_max_series(model, observations, meta, limit=5)
 ```
 
-`series` now contains matches sorted purely by the model's confidence,
-ignoring dates or kick-off times.
+Both helpers return matches sorted purely by the model's confidence, ignoring
+dates or kick-off times.


### PR DESCRIPTION
## Summary
- add helper to grab top-N matches for longest streak regardless of kick-off times
- document and showcase the new `max_series` and `rl_max_series` utilities

## Testing
- `python match_selector.py`
- `python -m py_compile match_selector.py stadiiony_szkolenie.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1e8cbc0832d9368f195d3cb79d3